### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,26 +6,26 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-Armdroid		KEYWORD1
-MTR_CHANNELS		KEYWORD1
+Armdroid	KEYWORD1
+MTR_CHANNELS	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-setSpeed		KEYWORD2
-getOffsets		KEYWORD2
+setSpeed	KEYWORD2
+getOffsets	KEYWORD2
 resetOffsetCounts	KEYWORD2
-driveMotor		KEYWORD2
-driveAllMotors		KEYWORD2
+driveMotor	KEYWORD2
+driveAllMotors	KEYWORD2
 driveMotorsAsynchronous KEYWORD2
-getAsyncState		KEYWORD2
-isRunning		KEYWORD2
-Start			KEYWORD2
-Pause			KEYWORD2
-Resume			KEYWORD2
-Stop			KEYWORD2
-torqueMotors		KEYWORD2
+getAsyncState	KEYWORD2
+isRunning	KEYWORD2
+Start	KEYWORD2
+Pause	KEYWORD2
+Resume	KEYWORD2
+Stop	KEYWORD2
+torqueMotors	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)
@@ -47,9 +47,9 @@ ARM_SHIELD_D8_PIN	LITERAL1
 ARM_AXIS_GRIPPER	LITERAL1
 ARM_AXIS_LEFT_WRIST	LITERAL1
 ARM_AXIS_RIGHT_WRIST	LITERAL1
-ARM_AXIS_ELBOW		LITERAL1
+ARM_AXIS_ELBOW	LITERAL1
 ARM_AXIS_SHOLDER	LITERAL1
-ARM_AXIS_BASE		LITERAL1
+ARM_AXIS_BASE	LITERAL1
 
 ASYNC_DRIVE_RUNNING	LITERAL1
 ASYNC_DRIVE_STOPPED	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords